### PR TITLE
live- scripts: remove unused field data from output

### DIFF
--- a/live-server-data-c.php
+++ b/live-server-data-c.php
@@ -47,12 +47,6 @@ $query = 'SELECT max(timestamp) as timestamp, (max(e_total)-min(e_total)) as de_
 	' WHERE timestamp BETWEEN ' . $today . ' AND ' . $tomorrow;
 $result = $mysqli->query($query);
 $row = mysqli_fetch_assoc($result);
-$diff['jaar']   = gmdate("Y", $row['timestamp']);
-$diff['maand']  = gmdate("m", $row['timestamp'])-1;
-$diff['dag']    = gmdate("d", $row['timestamp']);
-$diff['uur']    = gmdate("H", $row['timestamp']);
-$diff['minuut'] = gmdate("i", $row['timestamp']);
-$diff['sec']    = gmdate("s", $row['timestamp']);
 $diff['ts'] = $row['timestamp'] * 1000;
 $diff['p1_volume_prd'] = sprintf("%.3f", $row['de_day_total']/1000);
 $diff['p1_current_power_prd'] = $row['p_active'];

--- a/live-server-data-inverter.php
+++ b/live-server-data-inverter.php
@@ -45,9 +45,6 @@ $sqlcols = $inverter == 1 ? 'v_ac, i_ac, v_dc, p_active'
 			  : '(v_ac1+v_ac2+v_ac3)/3 as v_ac, (i_ac1+i_ac2+i_ac3) as i_ac, v_dc, (p_active1+p_active2+p_active3) as p_active';
 // haal de gegevens van de inverter op
 $de_day_total = 0;
-$diff['jaar']   = gmdate("Y", strtotime($d1));
-$diff['maand']  = gmdate("m", strtotime($d1))-1;
-$diff['dag']    = gmdate("d", strtotime($d1));
 foreach ($mysqli->query(
 		'SELECT timestamp, IF(temperature = 0, NULL, temperature) temperature, de_day, ' . $sqlcols .
 		' FROM ' . $table .
@@ -62,9 +59,6 @@ foreach ($mysqli->query(
 	$de_day_total += $row["de_day"];
 	$diff['op_id']  = "i";
 	$diff['serie']  = $dag[1];
-	$diff['uur']    = gmdate("H",$row['timestamp']);
-	$diff['minuut'] = gmdate("i",$row['timestamp']);
-	$diff['sec']    = gmdate("s",$row['timestamp']);
 	$diff['ts']    = ($today + date("H", $row['timestamp']) * 3600 + round(0.2 * date("i", $row['timestamp'])) * 5 * 60) * 1000;
 	$diff['temperature'] = sprintf("%.0f", $row['temperature'] * 2);
 	$diff['p1_volume_prd'] = sprintf("%.3f", $de_day_total/1000);

--- a/live-server-data-paneel.php
+++ b/live-server-data-paneel.php
@@ -58,12 +58,6 @@ while ($row = mysqli_fetch_assoc($result)) {
 		if ($row['optimizer'] == $op_id[$i][0]) {
 			$diff['serie']  = 0;
 			$diff['op_id']  = $i;
-			$diff['jaar']   = gmdate("Y", $row['timestamp']);
-			$diff['maand']  = gmdate("m", $row['timestamp'])-1;
-			$diff['dag']    = gmdate("d", $row['timestamp']);
-			$diff['uur']    = gmdate("H", $row['timestamp']);
-			$diff['minuut'] = gmdate("i", $row['timestamp']);
-			$diff['sec']    = gmdate("s", $row['timestamp']);
 			$diff['ts'] = $row['timestamp'] * 1000;
 			$diff['temperature'] = $row['temperature']*2;
 			$diff['p1_current_power_prd'] = sprintf("%.3f", $row['vermogen']);

--- a/live-server-data-s.php
+++ b/live-server-data-s.php
@@ -49,12 +49,6 @@ foreach ($mysqli->query(
 		' ORDER BY timestamp')
 		as $j => $row) {
 	$de_day_total += $row["de_day"];
-	$diff['jaar']   = gmdate("Y", $row['timestamp']);
-	$diff['maand']  = gmdate("m", $row['timestamp'])-1;
-	$diff['dag']    = gmdate("d", $row['timestamp']);
-	$diff['uur']    = gmdate("H", $row['timestamp']);
-	$diff['minuut'] = gmdate("i", $row['timestamp']);
-	$diff['sec']    = gmdate("s", $row['timestamp']);
 	$diff['ts']   = $row['timestamp'] * 1000;
 	$diff['p1_volume_prd'] = sprintf("%.3f", $de_day_total/1000);
 	$diff['p1_current_power_prd'] = $row['p_active'];


### PR DESCRIPTION
Now that the 'ts' fields is used to draw the graphs,
the 'jaar', ... 'sec' fields are not needed anymore.
This save a lot of calculations on the server side
(live scripts) and client side (javascript), and
reduce the amount of data transferred significantly.