### PR TITLE
Base PVGis calculations on reporting year/month

### DIFF
--- a/zonnepanelen.php
+++ b/zonnepanelen.php
@@ -600,7 +600,7 @@ EOF
 	var con_day = con_start_date.getDate();
 	var con_month = con_start_date.getMonth()+1;
 	var con_start_year = con_start_date.getFullYear();
-	var cdays = daysInMonth(con_month, con_start_year);
+	var cdays = daysInMonth(maand, jaar);
 	google.charts.load('current', {'packages':['gauge', 'line']});
 	google.charts.setOnLoadCallback(drawChart);
 


### PR DESCRIPTION
Using the contract month and year will always base
daily and monthy predictions on the same number of days
per month, while many months have a different daycount.